### PR TITLE
Use Control-Q keyboard shortcut on Macs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,8 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "Ctrl+Q"
+        "default": "Ctrl+Q",
+        "mac": "MacCtrl+Q"
       }
     }
   }


### PR DESCRIPTION
Use Control-Q keyboard shortcut instead of Command-Q on Macs:
https://github.com/OceanApart/QR-Code-Util-Web-Extension/issues/1